### PR TITLE
Disable pointer events for preview links and buttons

### DIFF
--- a/src/TranslationWidget.vue
+++ b/src/TranslationWidget.vue
@@ -485,6 +485,7 @@ class TranslationManager {
       element.onclick = null
       element.style.opacity = '0.7'
       element.style.cursor = 'pointer' // Keep pointer cursor for translation
+      element.style.pointerEvents = 'none' // Prevent blocking text nodes below
       element.setAttribute('data-translation-disabled', 'true')
       
       // For links, prevent navigation
@@ -518,6 +519,7 @@ class TranslationManager {
       // Re-enable the element
       element.style.opacity = ''
       element.style.cursor = ''
+      element.style.pointerEvents = '' // Restore original pointer-events
       element.removeAttribute('data-translation-disabled')
       
       // Restore button type if it was changed


### PR DESCRIPTION
Fix inability to select text nodes below disabled, absolutely positioned links by adding `pointer-events: none`.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-5d591bfa-04c1-4442-854c-8da073e4f660) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-5d591bfa-04c1-4442-854c-8da073e4f660)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)